### PR TITLE
Remove pytest as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     description="Compresses and downloads all files in any of the user's directories.",
     packages=setuptools.find_packages(),
     install_requires=[
-        'notebook', 'pytest'
+        'notebook'
     ],
     package_data={'jupyter-tree-download': ['static/*']},
     data_files=[


### PR DESCRIPTION
- Isn't used
- Even when used, should ideally be a dev dependency,
  not a runtime dependency