### PR TITLE
Switch default format to zip

### DIFF
--- a/jupyter_tree_download/handlers.py
+++ b/jupyter_tree_download/handlers.py
@@ -75,4 +75,15 @@ class TreeDownloadHandler(IPythonHandler):
         self.finish()
 
 class TreeDownload(Configurable):
-    compression = Unicode(u"gzip", help="Compression type.", config=True)
+    compression = Unicode(
+        "zip",
+        help="""Type of compression to use.
+
+        If 'zip' a .zip file is produced.
+        For anything else, a '.tar.{compression}' file is produced, via tar.
+
+        Appropriate compressor program (such as 'zip', 'tar', 'gzip', etc) must be
+        already installed in the environment
+        """,
+        config=True
+    )


### PR DESCRIPTION
Zip is the best supported format across operating systems -
particularly Windows. For most of our use cases, the compression
change should be trivial enough.

This does require the 'zip' program to be installed. It isn't
as widespread as 'bzip2' or 'gzip' on Linux machines, but
that's ok.